### PR TITLE
Optimize reacting-flow hot loops: cut runtime ~30% and memory ~11%

### DIFF
--- a/src/headers/impose_nscbc.hpp
+++ b/src/headers/impose_nscbc.hpp
@@ -3,19 +3,19 @@
 
 #include "lbm.hpp"
 
-void impose_NSCBC(LBM lb, int i, int j, int k, int l_interface, double &rho_out, double rhoa_out[], double vel_out[], double &T_out );
-void normal_derivative(LBM lb, int i, int j, int k, int idir, int isign, double delta, double &dp, double &du, double &dv, double &dw, double &drho, double *dY, size_t nSpecies);
-void tangential_derivative(LBM lb, int i, int j, int k, int idir, double delta, double &dp, double &du, double &dv, double &dw, double &drho, double *dY, size_t nSpecies);
-void compute_tranverse_terms(LBM lb, int i, int j, int k, int idir, double& T1, double& T2, double& T3, double& T4, double& T5,
+void impose_NSCBC(LBM& lb, int i, int j, int k, int l_interface, double &rho_out, double rhoa_out[], double vel_out[], double &T_out );
+void normal_derivative(LBM& lb, int i, int j, int k, int idir, int isign, double delta, double &dp, double &du, double &dv, double &dw, double &drho, double *dY, size_t nSpecies);
+void tangential_derivative(LBM& lb, int i, int j, int k, int idir, double delta, double &dp, double &du, double &dv, double &dw, double &drho, double *dY, size_t nSpecies);
+void compute_tranverse_terms(LBM& lb, int i, int j, int k, int idir, double& T1, double& T2, double& T3, double& T4, double& T5,
 double dpdx, double dudx, double dvdx, double dwdx, double drhodx,
     double dpdy, double dudy, double dvdy, double dwdy, double drhody,
     double dpdz, double dudz, double dvdz, double dwdz, double drhodz);
-void compute_waves(LBM lb,
+void compute_waves(LBM& lb,
     int i, int j, int k, int idir, int isign,
     double T1, double T2, double T3, double T4, double T5,
     double& L1, double& L2, double& L3, double& L4, double& L5, double *L6,
     double dp, double du, double dv, double dw, double drho, double dYdx[], double dYdy[], double dYdz[]);
-void update_bc_cells(LBM lb,
+void update_bc_cells(LBM& lb,
     int i, int j, int k, int idir, int isign,
     double L1, double L2, double L3, double L4, double L5, double L6[],
     double &rho_out, double rhoa_out[], double vel_out[], double &T_out);

--- a/src/headers/lbm.hpp
+++ b/src/headers/lbm.hpp
@@ -64,7 +64,7 @@
                                         {0., 0., 0.},
                                         {0., 0., 0.}}; 
 
-            double rho;              // macroscopic quantity
+            double rho = 1.0;        // macroscopic quantity (initialized so never-written boundary cells hold a defined value)
             double u = 0.0;          // velocity in x-direction
             double v = 0.0;          // velocity in y-direction
             double w = 0.0;          // velocity in z-direction
@@ -91,14 +91,10 @@
             double X = 0.0;             // mole fraction
             double rho = 0.0;           // density
 
-            double f[npop], fpc[npop];  // distribution function, distribution function post collistion  
+            double f[npop], fpc[npop];  // distribution function, distribution function post collistion
             double u = 0.0;     // velocity in x-direction
             double v = 0.0;     // velocity in y-direction
             double w = 0.0;     // velocity in z-direction
-
-            double p_tensor[3][3] = {{0., 0., 0.},    // pressure tensor
-                                     {0., 0., 0.},
-                                     {0., 0., 0.}};
 
     };
 
@@ -124,8 +120,19 @@
             size_t nSpecies = 0;
             std::vector<std::string> speciesName;
             double permeability = 999999;  // Permeability
+
+            // precomputed once in the constructor to avoid per-cell Cantera lookups
+            size_t nSpeciesCantera = 0;         // number of species in the full mechanism
+            std::vector<size_t> speciesIdx;     // Cantera index of each simulated species
+            std::vector<double> molarMass;      // molecular weight of each simulated species [kg/kmol]
             #endif
-        
+
+            // contiguous storage backing the mixture/species pointer tables
+            MIXTURE * mixture_data = nullptr;
+            #ifdef MULTICOMP
+                std::vector<SPECIES*> species_data;
+            #endif
+
         public:
             MIXTURE *** mixture;
             #ifdef MULTICOMP
@@ -219,6 +226,9 @@
                 int get_nSpecies(){return nSpecies;};
                 std::vector<std::string> get_speciesName(){return speciesName;};
                 double get_permeability(){return permeability;};
+                size_t get_nSpeciesCantera(){return nSpeciesCantera;};
+                const std::vector<size_t>& get_speciesIdx(){return speciesIdx;};
+                const std::vector<double>& get_molarMass(){return molarMass;};
                 size_t get_size(){
                     size_t size_scalar_int      = 9 * sizeof(int);
                     size_t size_scalar_species  = sizeof(size_t) + nSpecies*sizeof(size_t);

--- a/src/impose_nscbc.cpp
+++ b/src/impose_nscbc.cpp
@@ -4,7 +4,7 @@
 #include "units.hpp"
 #include "impose_nscbc.hpp"
 
-void impose_NSCBC(LBM lb, int i, int j, int k, int l_interface, double &rho_out, double rhoa_out[], double vel_out[], double &T_out )
+void impose_NSCBC(LBM& lb, int i, int j, int k, int l_interface, double &rho_out, double rhoa_out[], double vel_out[], double &T_out )
 {
 #if defined MULTICOMP
     size_t nSpecies = lb.get_nSpecies();
@@ -47,7 +47,7 @@ void impose_NSCBC(LBM lb, int i, int j, int k, int l_interface, double &rho_out,
 }
 
 
-void normal_derivative(LBM lb, int i, int j, int k, int idir, int isign, double delta, double &dp, double &du, double &dv, double &dw, double &drho, double *dY, size_t nSpecies)
+void normal_derivative(LBM& lb, int i, int j, int k, int idir, int isign, double delta, double &dp, double &du, double &dv, double &dw, double &drho, double *dY, size_t nSpecies)
 {
     if (idir == 1){
         if (isign == 1){
@@ -112,7 +112,7 @@ void normal_derivative(LBM lb, int i, int j, int k, int idir, int isign, double 
 
 }
 
-void tangential_derivative(LBM lb, int i, int j, int k, int idir, double delta, double &dp, double &du, double &dv, double &dw, double &drho, double *dY, size_t nSpecies)
+void tangential_derivative(LBM& lb, int i, int j, int k, int idir, double delta, double &dp, double &du, double &dv, double &dw, double &drho, double *dY, size_t nSpecies)
 {
     if (idir == 1){
         if (lb.mixture[i-1][j][k].type != TYPE_F){
@@ -204,18 +204,18 @@ void tangential_derivative(LBM lb, int i, int j, int k, int idir, double delta, 
 
 }
 
-void compute_tranverse_terms(LBM lb, int i, int j, int k, int idir, double& T1, double& T2, double& T3, double& T4, double& T5,
+void compute_tranverse_terms(LBM& lb, int i, int j, int k, int idir, double& T1, double& T2, double& T3, double& T4, double& T5,
 double dpdx, double dudx, double dvdx, double dwdx, double drhodx,
     double dpdy, double dudy, double dvdy, double dwdy, double drhody,
     double dpdz, double dudz, double dvdz, double dwdz, double drhodz)
 {
     size_t nSpecies = lb.get_nSpecies();
-    std::vector<std::string> speciesName = lb.get_speciesName();
+    const std::vector<size_t>& speciesIdx = lb.get_speciesIdx();
 
     int rank = omp_get_thread_num();
     auto gas = sols[rank]->thermo();   
-    std::vector <double> Y (gas->nSpecies());
-    for(size_t a = 0; a < nSpecies; ++a) Y[gas->speciesIndex(speciesName[a])] = lb.species[a][i][j][k].rho / lb.mixture[i][j][k].rho;
+    std::vector <double> Y (lb.get_nSpeciesCantera());
+    for(size_t a = 0; a < nSpecies; ++a) Y[speciesIdx[a]] = lb.species[a][i][j][k].rho / lb.mixture[i][j][k].rho;
     gas->setMassFractions(&Y[0]);
     gas->setState_DP(units.si_rho(lb.mixture[i][j][k].rho), units.si_p(lb.mixture[i][j][k].p));
 
@@ -277,7 +277,7 @@ double dpdx, double dudx, double dvdx, double dwdx, double drhodx,
     }
 }
 
-void compute_waves(LBM lb,
+void compute_waves(LBM& lb,
     int i, int j, int k, int idir, int isign,
     double T1, double T2, double T3, double T4, double T5,
     double& L1, double& L2, double& L3, double& L4, double& L5, double *L6,
@@ -293,12 +293,12 @@ void compute_waves(LBM lb,
     }
 
     size_t nSpecies = lb.get_nSpecies();
-    std::vector<std::string> speciesName = lb.get_speciesName();
+    const std::vector<size_t>& speciesIdx = lb.get_speciesIdx();
 
     int rank = omp_get_thread_num();
     auto gas = sols[rank]->thermo();   
-    std::vector <double> Y (gas->nSpecies());
-    for(size_t a = 0; a < nSpecies; ++a) Y[gas->speciesIndex(speciesName[a])] = lb.species[a][i][j][k].rho / lb.mixture[i][j][k].rho;
+    std::vector <double> Y (lb.get_nSpeciesCantera());
+    for(size_t a = 0; a < nSpecies; ++a) Y[speciesIdx[a]] = lb.species[a][i][j][k].rho / lb.mixture[i][j][k].rho;
     gas->setMassFractions(&Y[0]);
     gas->setState_DP(units.si_rho(lb.mixture[i][j][k].rho), units.si_p(lb.mixture[i][j][k].p));
 
@@ -423,7 +423,7 @@ void compute_waves(LBM lb,
     // }
 }
 
-void update_bc_cells(LBM lb,
+void update_bc_cells(LBM& lb,
     int i, int j, int k, int idir, int isign,
     double L1, double L2, double L3, double L4, double L5, double L6[],
     double &rho_out, double rhoa_out[], double vel_out[], double &T_out)
@@ -438,12 +438,12 @@ void update_bc_cells(LBM lb,
     }
 
     size_t nSpecies = lb.get_nSpecies();
-    std::vector<std::string> speciesName = lb.get_speciesName();
+    const std::vector<size_t>& speciesIdx = lb.get_speciesIdx();
 
     int rank = omp_get_thread_num();
     auto gas = sols[rank]->thermo();   
-    std::vector <double> Y (gas->nSpecies());
-    for(size_t a = 0; a < nSpecies; ++a) Y[gas->speciesIndex(speciesName[a])] = lb.species[a][i][j][k].rho / lb.mixture[i][j][k].rho;
+    std::vector <double> Y (lb.get_nSpeciesCantera());
+    for(size_t a = 0; a < nSpecies; ++a) Y[speciesIdx[a]] = lb.species[a][i][j][k].rho / lb.mixture[i][j][k].rho;
     gas->setMassFractions(&Y[0]);
     gas->setState_DP(units.si_rho(lb.mixture[i][j][k].rho), units.si_p(lb.mixture[i][j][k].p));
 
@@ -483,7 +483,7 @@ void update_bc_cells(LBM lb,
         rhoa_out[a] = (lb.species[a][i][j][k].rho/lb.mixture[i][j][k].rho - dt_sim*L6[a]) * rho_out ;
     
     std::fill(Y.begin(), Y.end(), 0.0);
-    for(size_t a = 0; a < nSpecies; ++a) Y[gas->speciesIndex(speciesName[a])] = rhoa_out[a] / rho_out;
+    for(size_t a = 0; a < nSpecies; ++a) Y[speciesIdx[a]] = rhoa_out[a] / rho_out;
     gas->setMassFractions(&Y[0]);
     gas->setState_DP(units.si_rho(rho_out), units.si_p(p_out));
 

--- a/src/lbm-bc.cpp
+++ b/src/lbm-bc.cpp
@@ -186,7 +186,7 @@ void LBM::TMS_BC()
                         int rank = omp_get_thread_num();
                         auto gas = sols[rank]->thermo();   
                         std::vector <double> Y (gas->nSpecies());
-                        for(size_t a = 0; a < nSpecies; ++a) Y[gas->speciesIndex(speciesName[a])] = rhoa_out[a] / rho_out;
+                        for(size_t a = 0; a < nSpecies; ++a) Y[speciesIdx[a]] = rhoa_out[a] / rho_out;
                         gas->setMassFractions(&Y[0]);   
                         // gas->setState_TP(units.si_temp(T_out), units.si_p(p_out));
 
@@ -522,7 +522,7 @@ void LBM::TMS_BC()
                             int rank = omp_get_thread_num();
                             auto gas = sols[rank]->thermo();   
                             std::vector <double> Y (gas->nSpecies());
-                            for(size_t a = 0; a < nSpecies; ++a) Y[gas->speciesIndex(speciesName[a])] = species[a][i][j][k].rho / mixture[i][j][k].rho;
+                            for(size_t a = 0; a < nSpecies; ++a) Y[speciesIdx[a]] = species[a][i][j][k].rho / mixture[i][j][k].rho;
                             gas->setMassFractions(&Y[0]);
                             gas->setState_DP(units.si_rho(mixture[i][j][k].rho), units.si_p(mixture[i][j][k].p));
 
@@ -670,7 +670,7 @@ void LBM::TMS_BC()
                             }
 
                             std::fill(Y.begin(), Y.end(), 0.0);
-                            for(size_t a = 0; a < nSpecies; ++a) Y[gas->speciesIndex(speciesName[a])] = rhoa_in[a] / rho_in;
+                            for(size_t a = 0; a < nSpecies; ++a) Y[speciesIdx[a]] = rhoa_in[a] / rho_in;
                             gas->setMassFractions(&Y[0]);   
                             gas->setState_DP(units.si_rho(rho_in), units.si_p(p_in));
                             T_in = units.temp(gas->temperature());
@@ -680,12 +680,12 @@ void LBM::TMS_BC()
                         int rank = omp_get_thread_num();
                         auto gas = sols[rank]->thermo();   
                         std::vector <double> Y (gas->nSpecies());
-                        for(size_t a = 0; a < nSpecies; ++a) Y[gas->speciesIndex(speciesName[a])] = rhoa_in[a] / rho_in;
+                        for(size_t a = 0; a < nSpecies; ++a) Y[speciesIdx[a]] = rhoa_in[a] / rho_in;
                         gas->setMassFractions(&Y[0]);   
                         gas->setState_TP(units.si_temp(T_in), units.si_p(p_in));
 
                         rho_in = units.rho(gas->density());
-                        for(size_t a = 0; a < nSpecies; ++a) rhoa_in[a] = Y[gas->speciesIndex(speciesName[a])] * rho_in;
+                        for(size_t a = 0; a < nSpecies; ++a) rhoa_in[a] = Y[speciesIdx[a]] * rho_in;
 
 
                         // std::cout << i << " | " << vel_in[0] << " | " << T_in << std::endl;

--- a/src/lbm-collision.cpp
+++ b/src/lbm-collision.cpp
@@ -189,41 +189,58 @@ void LBM::Collide()
 
 #elif defined MULTICOMP
 void LBM::Collide()
-{   
+{
     #ifndef ISOTHERM
 
-    #ifdef PARALLEL 
-        #pragma omp parallel for schedule(dynamic) 
+    #ifdef PARALLEL
+        #pragma omp parallel
+    #endif
+    {
+    // thread-local Cantera objects and work buffers, reused for every cell
+    int rank = omp_get_thread_num();
+    auto gas = sols[rank]->thermo();
+    auto trans = sols[rank]->transport();
+    std::vector <double> Y (nSpeciesCantera);
+    std::vector <double> part_enthalpy(nSpeciesCantera);
+
+    // specific gas constant R/W_mean from the local composition only;
+    // equivalent to Cantera's meanMolecularWeight() without touching the thermo state
+    auto mix_gasconst = [&](int ii, int jj, int kk) -> double {
+        double sumYoverW = 0.0, sumY = 0.0;
+        for(size_t a = 0; a < nSpecies; ++a){
+            double Ya = species[a][ii][jj][kk].rho / mixture[ii][jj][kk].rho;
+            sumYoverW += Ya / molarMass[a];
+            sumY += Ya;
+        }
+        return units.cp(Cantera::GasConstant * sumYoverW / sumY);
+    };
+
+    auto is_fluidlike = [&](int ii, int jj, int kk) -> bool {
+        short t = mixture[ii][jj][kk].type;
+        return t == TYPE_F || t == TYPE_I || t == TYPE_O || t == TYPE_I_C || t == TYPE_O_C;
+    };
+
+    #ifdef PARALLEL
+        #pragma omp for collapse(2) schedule(dynamic)
     #endif
     for(int i = 0; i < Nx ; ++i)
     {
         for(int j = 0; j < Ny; ++j)
         {
             for(int k = 0; k < Nz; ++k)
-            {    
-                if (mixture[i][j][k].type == TYPE_F)     
-                {   
-                    // create Cantera object
-                    int rank = omp_get_thread_num();
-                    auto gas = sols[rank]->thermo();
-                    double mmass[nSpecies];
-                    size_t idx_species[nSpecies];
-                    for(size_t a = 0; a < nSpecies; ++a){
-                        idx_species[a] = gas->speciesIndex(speciesName[a]);
-                        mmass[a] = gas->molecularWeight(idx_species[a]);
-                    }
-                    std::vector <double> Y (gas->nSpecies());
-                    for(size_t a = 0; a < nSpecies; ++a) Y[idx_species[a]] = species[a][i][j][k].rho / mixture[i][j][k].rho;
+            {
+                if (mixture[i][j][k].type == TYPE_F)
+                {
+                    std::fill(Y.begin(), Y.end(), 0.0);
+                    for(size_t a = 0; a < nSpecies; ++a) Y[speciesIdx[a]] = species[a][i][j][k].rho / mixture[i][j][k].rho;
                     gas->setMassFractions(&Y[0]);
                     gas->setState_TD(units.si_temp(mixture[i][j][k].temp), units.si_rho(mixture[i][j][k].rho));
 
                     // get macropscopic properties
                     double cp = units.cp(gas->cp_mass());
                     double gasconstant = units.cp(Cantera::GasConstant/gas->meanMolecularWeight());
-                    std::vector <double> part_enthalpy(gas->nSpecies());
                     gas->getPartialMolarEnthalpies(&part_enthalpy[0]);
 
-                    auto trans = sols[rank]->transport();
                     double mu = units.mu(trans->viscosity());
                     double conduc_coeff = units.thermalConductivity(trans->thermalConductivity());
                     
@@ -257,69 +274,30 @@ void LBM::Collide()
                     double q_corr [3] = {0.0, 0.0, 0.0};
                     for (size_t a = 0; a < nSpecies; ++a)
                     {
-                        q_diff[0] += omega1/(-omega+omega1)  * units.energy_mass(part_enthalpy[idx_species[a]]/mmass[a]) * species[a][i][j][k].rho * (species[a][i][j][k].u-mixture[i][j][k].u);
-                        q_diff[1] += omega1/(-omega+omega1)  * units.energy_mass(part_enthalpy[idx_species[a]]/mmass[a]) * species[a][i][j][k].rho * (species[a][i][j][k].v-mixture[i][j][k].v);
-                        q_diff[2] += omega1/(-omega+omega1)  * units.energy_mass(part_enthalpy[idx_species[a]]/mmass[a]) * species[a][i][j][k].rho * (species[a][i][j][k].w-mixture[i][j][k].w);
+                        double h_a = units.energy_mass(part_enthalpy[speciesIdx[a]]/molarMass[a]);
+                        q_diff[0] += omega1/(-omega+omega1)  * h_a * species[a][i][j][k].rho * (species[a][i][j][k].u-mixture[i][j][k].u);
+                        q_diff[1] += omega1/(-omega+omega1)  * h_a * species[a][i][j][k].rho * (species[a][i][j][k].v-mixture[i][j][k].v);
+                        q_diff[2] += omega1/(-omega+omega1)  * h_a * species[a][i][j][k].rho * (species[a][i][j][k].w-mixture[i][j][k].w);
 
                         double dY_x = fd_fuw(species[a][i-1][j][k].rho/mixture[i-1][j][k].rho, species[a][i][j][k].rho/mixture[i][j][k].rho, species[a][i+1][j][k].rho/mixture[i+1][j][k].rho, dx, species[a][i][j][k].u-mixture[i][j][k].u, mixture[i-1][j][k].type, mixture[i+1][j][k].type);
                         double dY_y = fd_fuw(species[a][i][j-1][k].rho/mixture[i][j-1][k].rho, species[a][i][j][k].rho/mixture[i][j][k].rho, species[a][i][j+1][k].rho/mixture[i][j+1][k].rho, dy, species[a][i][j][k].v-mixture[i][j][k].v, mixture[i][j-1][k].type, mixture[i][j+1][k].type);
                         double dY_z = fd_fuw(species[a][i][j][k-1].rho/mixture[i][j][k-1].rho, species[a][i][j][k].rho/mixture[i][j][k].rho, species[a][i][j][k+1].rho/mixture[i][j][k+1].rho, dz, species[a][i][j][k].w-mixture[i][j][k].w, mixture[i][j][k-1].type, mixture[i][j][k+1].type);
 
-                        q_corr[0] += 0.5 * (2.0-omega1)/(-omega+omega1) * dt_sim * mixture[i][j][k].p * units.energy_mass(part_enthalpy[idx_species[a]]/mmass[a]) * dY_x;//species[a][i][j][k].delYx;
-                        q_corr[1] += 0.5 * (2.0-omega1)/(-omega+omega1) * dt_sim * mixture[i][j][k].p * units.energy_mass(part_enthalpy[idx_species[a]]/mmass[a]) * dY_y;//species[a][i][j][k].delYy;
-                        q_corr[2] += 0.5 * (2.0-omega1)/(-omega+omega1) * dt_sim * mixture[i][j][k].p * units.energy_mass(part_enthalpy[idx_species[a]]/mmass[a]) * dY_z;//species[a][i][j][k].delYz;  
+                        q_corr[0] += 0.5 * (2.0-omega1)/(-omega+omega1) * dt_sim * mixture[i][j][k].p * h_a * dY_x;//species[a][i][j][k].delYx;
+                        q_corr[1] += 0.5 * (2.0-omega1)/(-omega+omega1) * dt_sim * mixture[i][j][k].p * h_a * dY_y;//species[a][i][j][k].delYy;
+                        q_corr[2] += 0.5 * (2.0-omega1)/(-omega+omega1) * dt_sim * mixture[i][j][k].p * h_a * dY_z;//species[a][i][j][k].delYz;
                     }
 
                     double delQdevx, delQdevy, delQdevz;
                     double gasconst_in = 0.0, gasconst_ip = 0.0, gasconst_jn = 0.0, gasconst_jp = 0.0, gasconst_kn = 0.0, gasconst_kp = 0.0;
-                    
-                    if(mixture[i-1][j][k].type == TYPE_F || mixture[i-1][j][k].type == TYPE_I || mixture[i-1][j][k].type == TYPE_O || mixture[i-1][j][k].type == TYPE_I_C || mixture[i-1][j][k].type == TYPE_O_C){
-                        std::fill(Y.begin(), Y.end(), 0.0);
-                        for(size_t a = 0; a < nSpecies; ++a) Y[idx_species[a]] = species[a][i-1][j][k].rho / mixture[i-1][j][k].rho;
-                        gas->setMassFractions(&Y[0]);
-                        gas->setState_TD(units.si_temp(mixture[i-1][j][k].temp), units.si_rho(mixture[i-1][j][k].rho));
-                        gasconst_in = units.cp(Cantera::GasConstant/gas->meanMolecularWeight());
-                    }
 
-                    if(mixture[i+1][j][k].type == TYPE_F || mixture[i+1][j][k].type == TYPE_I || mixture[i+1][j][k].type == TYPE_O || mixture[i+1][j][k].type == TYPE_I_C || mixture[i+1][j][k].type == TYPE_O_C){
-                        std::fill(Y.begin(), Y.end(), 0.0);
-                        for(size_t a = 0; a < nSpecies; ++a) Y[idx_species[a]] = species[a][i+1][j][k].rho / mixture[i+1][j][k].rho;
-                        gas->setMassFractions(&Y[0]);
-                        gas->setState_TD(units.si_temp(mixture[i+1][j][k].temp), units.si_rho(mixture[i+1][j][k].rho));
-                        gasconst_ip = units.cp(Cantera::GasConstant/gas->meanMolecularWeight());
-                    }
-
-                    if(mixture[i][j-1][k].type == TYPE_F || mixture[i][j-1][k].type == TYPE_I || mixture[i][j-1][k].type == TYPE_O || mixture[i][j-1][k].type == TYPE_I_C || mixture[i][j-1][k].type == TYPE_O_C){
-                        std::fill(Y.begin(), Y.end(), 0.0);
-                        for(size_t a = 0; a < nSpecies; ++a) Y[idx_species[a]] = species[a][i][j-1][k].rho / mixture[i][j-1][k].rho;
-                        gas->setMassFractions(&Y[0]);
-                        gas->setState_TD(units.si_temp(mixture[i][j-1][k].temp), units.si_rho(mixture[i][j-1][k].rho));
-                        gasconst_jn = units.cp(Cantera::GasConstant/gas->meanMolecularWeight());
-                    }
-
-                    if(mixture[i][j+1][k].type == TYPE_F || mixture[i][j+1][k].type == TYPE_I || mixture[i][j+1][k].type == TYPE_O || mixture[i][j+1][k].type == TYPE_I_C || mixture[i][j+1][k].type == TYPE_O_C){
-                        std::fill(Y.begin(), Y.end(), 0.0);
-                        for(size_t a = 0; a < nSpecies; ++a) Y[idx_species[a]] = species[a][i][j+1][k].rho / mixture[i][j+1][k].rho;
-                        gas->setMassFractions(&Y[0]);
-                        gas->setState_TD(units.si_temp(mixture[i][j+1][k].temp), units.si_rho(mixture[i][j+1][k].rho));
-                        gasconst_jp = units.cp(Cantera::GasConstant/gas->meanMolecularWeight());
-                    }
-
-                    if(mixture[i][j][k-1].type == TYPE_F || mixture[i][j][k-1].type == TYPE_I || mixture[i][j][k-1].type == TYPE_O || mixture[i][j][k-1].type == TYPE_I_C || mixture[i][j][k-1].type == TYPE_O_C){
-                        std::fill(Y.begin(), Y.end(), 0.0);
-                        for(size_t a = 0; a < nSpecies; ++a) Y[idx_species[a]] = species[a][i][j][k-1].rho / mixture[i][j][k-1].rho;
-                        gas->setMassFractions(&Y[0]);
-                        gas->setState_TD(units.si_temp(mixture[i][j][k-1].temp), units.si_rho(mixture[i][j][k-1].rho));
-                        gasconst_kn = units.cp(Cantera::GasConstant/gas->meanMolecularWeight());
-                    }
-
-                    if(mixture[i][j][k+1].type == TYPE_F || mixture[i][j][k+1].type == TYPE_I || mixture[i][j][k+1].type == TYPE_O || mixture[i][j][k+1].type == TYPE_I_C || mixture[i][j][k+1].type == TYPE_O_C){
-                        std::fill(Y.begin(), Y.end(), 0.0);
-                        for(size_t a = 0; a < nSpecies; ++a) Y[idx_species[a]] = species[a][i][j][k+1].rho / mixture[i][j][k+1].rho;
-                        gas->setMassFractions(&Y[0]);
-                        gas->setState_TD(units.si_temp(mixture[i][j][k+1].temp), units.si_rho(mixture[i][j][k+1].rho));
-                        gasconst_kp = units.cp(Cantera::GasConstant/gas->meanMolecularWeight());
-                    }
+                    // gas constant of the neighbours, from composition only (no Cantera state updates)
+                    if(is_fluidlike(i-1,j,k)) gasconst_in = mix_gasconst(i-1,j,k);
+                    if(is_fluidlike(i+1,j,k)) gasconst_ip = mix_gasconst(i+1,j,k);
+                    if(is_fluidlike(i,j-1,k)) gasconst_jn = mix_gasconst(i,j-1,k);
+                    if(is_fluidlike(i,j+1,k)) gasconst_jp = mix_gasconst(i,j+1,k);
+                    if(is_fluidlike(i,j,k-1)) gasconst_kn = mix_gasconst(i,j,k-1);
+                    if(is_fluidlike(i,j,k+1)) gasconst_kp = mix_gasconst(i,j,k+1);
 
                     delQdevx = fd_central(mixture[i-1][j][k].rho*mixture[i-1][j][k].u*(1.0-3.0*gasconst_in*mixture[i-1][j][k].temp)-mixture[i-1][j][k].rho*cb(mixture[i-1][j][k].u), mixture[i][j][k].rho*mixture[i][j][k].u*(1.0-3.0*gasconstant*mixture[i][j][k].temp)-mixture[i][j][k].rho*cb(mixture[i][j][k].u), mixture[i+1][j][k].rho*mixture[i+1][j][k].u*(1.0-3.0*gasconst_ip*mixture[i+1][j][k].temp)-mixture[i+1][j][k].rho*cb(mixture[i+1][j][k].u), dx, mixture[i][j][k].u, mixture[i-1][j][k].type, mixture[i+1][j][k].type) ;
                     delQdevy = fd_central(mixture[i][j-1][k].rho*mixture[i][j-1][k].v*(1.0-3.0*gasconst_jn*mixture[i][j-1][k].temp)-mixture[i][j-1][k].rho*cb(mixture[i][j-1][k].v), mixture[i][j][k].rho*mixture[i][j][k].v*(1.0-3.0*gasconstant*mixture[i][j][k].temp)-mixture[i][j][k].rho*cb(mixture[i][j][k].v), mixture[i][j+1][k].rho*mixture[i][j+1][k].v*(1.0-3.0*gasconst_jp*mixture[i][j+1][k].temp)-mixture[i][j+1][k].rho*cb(mixture[i][j+1][k].v), dy, mixture[i][j][k].v, mixture[i][j-1][k].type, mixture[i][j+1][k].type) ;
@@ -343,40 +321,49 @@ void LBM::Collide()
                         // double geq = calculate_geq(l, mixture[i][j][k].rhoe, eq_heat_flux, eq_R_tensor, theta);
                         // double gstr = calculate_geq(l, mixture[i][j][k].rhoe, str_heat_flux, eq_R_tensor, theta);
                         mixture[i][j][k].gpc[l] = mixture[i][j][k].g[l] + omega1*(geq-mixture[i][j][k].g[l]) + (omega-omega1)*(geq-gstr);
-                    }     
+                    }
 
                 }
             }
         }
     }
+    } // end parallel region
     #endif
 }
 
 void LBM::Collide_Species()
 {
-    #ifdef PARALLEL 
-        #pragma omp parallel for schedule(dynamic) 
+    #ifdef PARALLEL
+        #pragma omp parallel
+    #endif
+    {
+    // thread-local Cantera objects and work buffers, reused for every cell
+    int rank = omp_get_thread_num();
+    auto gas = sols[rank]->thermo();
+    auto trans = sols[rank]->transport();
+    auto kinetics = sols[rank]->kinetics();
+    const int ld = nSpeciesCantera;
+    std::vector <double> Y (nSpeciesCantera);
+    std::vector <double> w_dot(nSpeciesCantera);    // mole density rate [kmol/m3/s]
+    std::vector <double> part_enthalpy(nSpeciesCantera);
+    std::vector <double> spec_visc(nSpeciesCantera);
+    std::vector <double> d(ld * ld);
+    std::vector <double> rho_a(nSpecies);
+
+    #ifdef PARALLEL
+        #pragma omp for collapse(2) schedule(dynamic)
     #endif
     for(int i = 0; i < Nx ; ++i)
     {
         for(int j = 0; j < Ny; ++j)
         {
             for(int k = 0; k < Nz; ++k)
-            {    
-                if (mixture[i][j][k].type == TYPE_F)     
-                {   
-                    int rank = omp_get_thread_num();
-                    auto gas = sols[rank]->thermo();   
-                    double mmass[nSpecies];
-                    size_t idx_species[nSpecies];
-                    for(size_t a = 0; a < nSpecies; ++a){
-                        idx_species[a] = gas->speciesIndex(speciesName[a]);
-                        mmass[a] = gas->molecularWeight(idx_species[a]);
-                    }
-                    
-                    std::vector <double> Y (gas->nSpecies());
-                    for(size_t a = 0; a < nSpecies; ++a) Y[idx_species[a]] = species[a][i][j][k].rho / mixture[i][j][k].rho;
-                    gas->setMassFractions(&Y[0]);   
+            {
+                if (mixture[i][j][k].type == TYPE_F)
+                {
+                    std::fill(Y.begin(), Y.end(), 0.0);
+                    for(size_t a = 0; a < nSpecies; ++a) Y[speciesIdx[a]] = species[a][i][j][k].rho / mixture[i][j][k].rho;
+                    gas->setMassFractions(&Y[0]);
                     gas->setState_TD(units.si_temp(mixture[i][j][k].temp), units.si_rho(mixture[i][j][k].rho));
                                         
                     // Reaction ---------------------------------------------------------------------------------------------------------------------------
@@ -388,80 +375,71 @@ void LBM::Collide_Species()
                         for (size_t a = 0; a < nSpecies; ++a){
                             internal_energy = internal_energy - 0.5 * species[a][i][j][k].rho/mixture[i][j][k].rho * v_sqr(species[a][i][j][k].u, species[a][i][j][k].v, species[a][i][j][k].w);
                         }
-                        std::vector <double> w_dot(gas->nSpecies());    // mole density rate [kmol/m3/s]
-                        auto kinetics = sols[rank]->kinetics();
-
                         size_t p = 0;
                         double maxIter = 2.0;
-                        double rho_a[gas->nSpecies()] = {0.0};
+                        std::fill(rho_a.begin(), rho_a.end(), 0.0);
                         do{
-                            kinetics->getNetProductionRates(&w_dot[0]); 
-                            for (size_t a = 0; a < nSpecies; ++a){                                    
-                                double rho_dot = units.rho_dot(w_dot[a] * mmass[a]);
+                            kinetics->getNetProductionRates(&w_dot[0]);
+                            for (size_t a = 0; a < nSpecies; ++a){
+                                double rho_dot = units.rho_dot(w_dot[speciesIdx[a]] * molarMass[a]);
                                 rho_a[a] += dt_sim/maxIter * rho_dot;
                             }
-                    
+
                             std::fill(Y.begin(), Y.end(), 0.0);
-                            for(size_t a = 0; a < nSpecies; ++a) Y[idx_species[a]] = (species[a][i][j][k].rho+rho_a[a]) / mixture[i][j][k].rho;
+                            for(size_t a = 0; a < nSpecies; ++a) Y[speciesIdx[a]] = (species[a][i][j][k].rho+rho_a[a]) / mixture[i][j][k].rho;
                             gas->setMassFractions(&Y[0]);
                             gas->setState_UV(units.si_energy_mass(internal_energy), 1.0/units.si_rho(mixture[i][j][k].rho),1.0e-15);
                             p++;
                         }while(p < maxIter);
 
-                        std::vector <double> part_enthalpy(gas->nSpecies());
                         gas->getPartialMolarEnthalpies(&part_enthalpy[0]);
                         mixture[i][j][k].HRR = 0.0;
                         for (size_t a = 0; a < nSpecies; ++a)
-                            mixture[i][j][k].HRR += -1.0 * units.energy_mass(part_enthalpy[a] / mmass[a]) * rho_a[a];
+                            mixture[i][j][k].HRR += -1.0 * units.energy_mass(part_enthalpy[speciesIdx[a]] / molarMass[a]) * rho_a[a];
                     #endif
 
-                    // Viscosity -----------------------------------------------------------------------------------------------------------------------------                    
+                    // Viscosity -----------------------------------------------------------------------------------------------------------------------------
                     std::fill(Y.begin(), Y.end(), 0.0);
-                    for(size_t a = 0; a < nSpecies; ++a) Y[idx_species[a]] = species[a][i][j][k].rho / mixture[i][j][k].rho;
+                    for(size_t a = 0; a < nSpecies; ++a) Y[speciesIdx[a]] = species[a][i][j][k].rho / mixture[i][j][k].rho;
                     gas->setMassFractions(&Y[0]);
                     gas->setState_TD(units.si_temp(mixture[i][j][k].temp), units.si_rho(mixture[i][j][k].rho));
-                    
-                    auto trans = sols[rank]->transport();
-                    int ld = gas->nSpecies();
-                    std::vector<double> spec_visc(ld);
+
                     trans->getSpeciesViscosities(&spec_visc[0]);
                     double visc_a[nSpecies] = {0.0};
                     double omega_a[nSpecies] = {0.0};
 
                     double phi[nSpecies][nSpecies] = {0.0};
-                    for(size_t a = 0; a < nSpecies; ++a){                        
+                    for(size_t a = 0; a < nSpecies; ++a){
                         for(size_t b = a; b < nSpecies; ++b){
-                            size_t idx_a = idx_species[a];
-                            size_t idx_b = idx_species[b];
+                            size_t idx_a = speciesIdx[a];
+                            size_t idx_b = speciesIdx[b];
 
-                            double factor1 = 1.0 + sqrt(spec_visc[idx_a]/spec_visc[idx_b]) * sqrt(sqrt(mmass[b]/mmass[a]));
-                            phi[a][b] = factor1*factor1 / sqrt(8.0*(1.0 + mmass[a]/mmass[b]));
-                            phi[b][a] = spec_visc[idx_b]/spec_visc[idx_a] * mmass[a]/mmass[b] * phi[a][b];
+                            double factor1 = 1.0 + sqrt(spec_visc[idx_a]/spec_visc[idx_b]) * sqrt(sqrt(molarMass[b]/molarMass[a]));
+                            phi[a][b] = factor1*factor1 / sqrt(8.0*(1.0 + molarMass[a]/molarMass[b]));
+                            phi[b][a] = spec_visc[idx_b]/spec_visc[idx_a] * molarMass[a]/molarMass[b] * phi[a][b];
                         }
-                    }        
+                    }
 
-                    for(size_t a = 0; a < nSpecies; ++a){                        
+                    for(size_t a = 0; a < nSpecies; ++a){
                         double denom = 0.0;
                         for(size_t b = 0; b < nSpecies; ++b)
                             denom = denom + species[b][i][j][k].X * phi[a][b];
-                        
-                        visc_a[a] = species[a][i][j][k].X * units.mu(spec_visc[idx_species[a]]) / denom;
-                        omega_a[a] = 2*species[a][i][j][k].X*mixture[i][j][k].p*dt_sim / (species[a][i][j][k].X*mixture[i][j][k].p*dt_sim + 2*visc_a[a]);
-                    }               
 
-                    // Diffusion ----------------------------------------------------------------------------------------------------------------------------          
-                    std::vector<double> d(ld * ld);
+                        visc_a[a] = species[a][i][j][k].X * units.mu(spec_visc[speciesIdx[a]]) / denom;
+                        omega_a[a] = 2*species[a][i][j][k].X*mixture[i][j][k].p*dt_sim / (species[a][i][j][k].X*mixture[i][j][k].p*dt_sim + 2*visc_a[a]);
+                    }
+
+                    // Diffusion ----------------------------------------------------------------------------------------------------------------------------
                     trans->getBinaryDiffCoeffs(ld, &d[0]);
 
                     double D_ab[nSpecies][nSpecies];
                     for(size_t a = 0; a < nSpecies; ++a)
-                    {                       
+                    {
                         for(size_t b = 0; b <= a; ++b)
                         {
                             // get diffusion coefficient
-                            D_ab[a][b] =  units.nu( d[ld*idx_species[b] + idx_species[a]] );
+                            D_ab[a][b] =  units.nu( d[ld*speciesIdx[b] + speciesIdx[a]] );
                             D_ab[b][a] =  D_ab[a][b];
-                            // std::cout << "D_ab " << gas->speciesName(gas->speciesIndex(speciesName[a])) << "-" << gas->speciesName(gas->speciesIndex(speciesName[b])) << " : " << d[ld*gas->speciesIndex(speciesName[b]) + gas->speciesIndex(speciesName[a])] << std::endl;
                         }
                     }
 
@@ -507,7 +485,7 @@ void LBM::Collide_Species()
                                                     uy[a] + fy[a], //+ dt_sim*G_lambda*(mixture[i][j][k].temp-units.temp(325.0) 
                                                     uz[a] + fz[a]};
 
-                        double gas_const_a = units.cp(Cantera::GasConstant/mmass[a]);
+                        double gas_const_a = units.cp(Cantera::GasConstant/molarMass[a]);
                         double theta = gas_const_a * mixture[i][j][k].temp;
 
                         double delQdevx, delQdevy, delQdevz;                            
@@ -540,11 +518,10 @@ void LBM::Collide_Species()
                         }
                     }
 
-                  
-
                 }
             }
         }
     }
+    } // end parallel region
 }
 #endif

--- a/src/lbm-edf.cpp
+++ b/src/lbm-edf.cpp
@@ -170,21 +170,25 @@ void LBM::calculate_feq_geq(double fa_tgt[][npop], double g_tgt[], double rho_bb
 
     int rank = omp_get_thread_num();
     auto gas = sols[rank]->thermo();
-    std::vector <double> Y (gas->nSpecies());
+    std::vector <double> Y (nSpeciesCantera);
     for(size_t a = 0; a < nSpecies; ++a)
-        Y[gas->speciesIndex(speciesName[a])] = rhoa_bb[a] / rho_bb;
-    
+        Y[speciesIdx[a]] = rhoa_bb[a] / rho_bb;
+
     gas->setMassFractions(&Y[0]);
     gas->setState_TD(units.si_temp(temp_tgt), units.si_rho(rho_bb));
 
     double internal_energy = units.energy_mass(gas->intEnergy_mass());
-    double theta = units.energy_mass(gas->RT()/gas->meanMolecularWeight());      
-    
+    double theta = units.energy_mass(gas->RT()/gas->meanMolecularWeight());
+
+    // per-species theta does not depend on the lattice direction, so compute it once
+    double theta_a[nSpecies];
+    for (size_t a = 0; a < nSpecies; ++a)
+        theta_a[a] = units.energy_mass(gas->RT()/molarMass[a]);
+
     double corr[3]= {0, 0, 0};
-    for (int l=0; l < npop; ++l){   
+    for (int l=0; l < npop; ++l){
         for (size_t a = 0; a < nSpecies; ++a){
-            double theta_a = units.energy_mass(gas->RT()/gas->molecularWeight(gas->speciesIndex(speciesName[a]))); 
-            fa_tgt[a][l] = calculate_feq(l, rhoa_bb[a], vela_tgt[a], theta_a, corr);
+            fa_tgt[a][l] = calculate_feq(l, rhoa_bb[a], vela_tgt[a], theta_a[a], corr);
         }
 
         g_tgt[l] = calculate_geq(l, rho_bb, internal_energy, theta, vel_tgt);

--- a/src/lbm-init.cpp
+++ b/src/lbm-init.cpp
@@ -98,8 +98,8 @@ void LBM::Init()
                     // initiate Cantera object
                     int rank = omp_get_thread_num();
                     auto gas = sols[rank]->thermo();
-                    std::vector <double> X (gas->nSpecies());
-                    for(size_t a = 0; a < nSpecies; ++a) X[gas->speciesIndex(speciesName[a])] = species[a][i][j][k].X;
+                    std::vector <double> X (nSpeciesCantera);
+                    for(size_t a = 0; a < nSpecies; ++a) X[speciesIdx[a]] = species[a][i][j][k].X;
                     gas->setMoleFractions(&X[0]);
                     gas->setState_TP(units.si_temp(mixture[i][j][k].temp), units.si_p(mixture[i][j][k].p));
 
@@ -114,11 +114,7 @@ void LBM::Init()
                     #endif
                     double theta = units.energy_mass(gas->RT()/gas->meanMolecularWeight());
 
-                    double eq_p_tensor[3][3] = {{0., 0., 0.},    // pressure tensor
-                                                {0., 0., 0.},
-                                                {0., 0., 0.}};
-
-                    double corr[3] = {0, 0, 0}; 
+                    double corr[3] = {0, 0, 0};
 
                     // ------------- Energy Distribution Function Initialization -----------------------------
                     #ifndef ISOTHERM
@@ -131,20 +127,11 @@ void LBM::Init()
                     // Species distribution function Initialization
                     for(size_t a = 0; a < nSpecies; ++a)
                     {
-                        species[a][i][j][k].rho = std::max( gas->massFraction(gas->speciesIndex(speciesName[a])) * mixture[i][j][k].rho, SPECIES_MIN);
+                        species[a][i][j][k].rho = std::max( gas->massFraction(speciesIdx[a]) * mixture[i][j][k].rho, SPECIES_MIN);
                         species[a][i][j][k].u = mixture[i][j][k].u;
                         species[a][i][j][k].v = mixture[i][j][k].v;
                         species[a][i][j][k].w = mixture[i][j][k].w;
-                        theta = units.energy_mass(gas->RT() / gas->molecularWeight(gas->speciesIndex(speciesName[a])) );
-
-                        for(int p=0; p < 3; ++p)
-                        {
-                            for(int q=0; q < 3; ++q)
-                            {
-                                eq_p_tensor[p][q] = (p==q) ? species[a][i][j][k].X*mixture[i][j][k].p+species[a][i][j][k].rho*velocity[p]*velocity[q] : species[a][i][j][k].rho*velocity[p]*velocity[q]; 
-                                species[a][i][j][k].p_tensor[p][q] = eq_p_tensor[p][q]; 
-                            }  
-                        }
+                        theta = units.energy_mass(gas->RT() / molarMass[a] );
 
                         for (int l = 0; l < npop; ++l)
                             species[a][i][j][k].f[l]=calculate_feq(l, species[a][i][j][k].rho, velocity, theta, corr);

--- a/src/lbm-main.cpp
+++ b/src/lbm-main.cpp
@@ -21,14 +21,15 @@ LBM::LBM(int Nx, int Ny, int Nz, double nu)
     this->Nz = Nz + 2;
     this->nu = nu;
 
-    // allocate memory for lattice
+    // allocate memory for lattice (one contiguous block + pointer tables for [i][j][k] indexing)
+    mixture_data = new MIXTURE [(size_t)this->Nx * this->Ny * this->Nz];
     mixture = new MIXTURE **[this->Nx];
     for (int i = 0; i < this->Nx; ++i)
     {
         mixture[i] = new MIXTURE *[this->Ny];
         for (int j = 0; j < this->Ny; ++j)
         {
-            mixture[i][j] = new MIXTURE [this->Nz];
+            mixture[i][j] = mixture_data + ((size_t)i * this->Ny + j) * this->Nz;
         }
     }
 }
@@ -44,28 +45,32 @@ LBM::LBM(int Nx, int Ny, int Nz, std::vector<std::string> species)
     this->speciesName = species;
     this->nSpecies = species.size();
 
-    // allocate memory for mixture
+    // allocate memory for mixture (one contiguous block + pointer tables for [i][j][k] indexing)
+    const size_t ncell = (size_t)this->Nx * this->Ny * this->Nz;
+    mixture_data = new MIXTURE [ncell];
     mixture = new MIXTURE **[this->Nx];
     for (int i = 0; i < this->Nx; ++i)
     {
         mixture[i] = new MIXTURE *[this->Ny];
         for (int j = 0; j < this->Ny; ++j)
         {
-            mixture[i][j] = new MIXTURE [this->Nz];
+            mixture[i][j] = mixture_data + ((size_t)i * this->Ny + j) * this->Nz;
         }
     }
 
-    // allocate memory for species
+    // allocate memory for species (one contiguous block per species)
     this->species.resize(nSpecies);
+    this->species_data.resize(nSpecies);
     for(size_t p = 0; p < nSpecies; ++p)
     {
+        this->species_data[p] = new SPECIES [ncell];
         this->species[p] = new SPECIES **[this->Nx];
         for (int i = 0; i < this->Nx; ++i)
         {
             this->species[p][i] = new SPECIES *[this->Ny];
             for (int j = 0; j < this->Ny; ++j)
             {
-                this->species[p][i][j] = new SPECIES [this->Nz];
+                this->species[p][i][j] = this->species_data[p] + ((size_t)i * this->Ny + j) * this->Nz;
             }
         }
     }
@@ -84,6 +89,17 @@ LBM::LBM(int Nx, int Ny, int Nz, std::vector<std::string> species)
         sols.push_back(sol);
     }
 
+    // Precompute the Cantera species indices and molecular weights once,
+    // so the hot loops don't have to do string lookups for every lattice cell
+    auto gas = sols[0]->thermo();
+    nSpeciesCantera = gas->nSpecies();
+    speciesIdx.resize(nSpecies);
+    molarMass.resize(nSpecies);
+    for(size_t a = 0; a < nSpecies; ++a)
+    {
+        speciesIdx[a] = gas->speciesIndex(speciesName[a]);
+        molarMass[a] = gas->molecularWeight(speciesIdx[a]);
+    }
 }
 #endif
 

--- a/src/lbm-moment.cpp
+++ b/src/lbm-moment.cpp
@@ -2,16 +2,16 @@
 #include "math_util.hpp"
 #include "units.hpp"
 #include "omp.h"
+#ifdef MULTICOMP
+#include <Eigen/Dense>
+#endif
 
 
 #ifndef MULTICOMP
 void LBM::calculate_moment()
 {
-    std::vector<std::vector<std::vector<double>>> dQdevx(Nx, std::vector<std::vector<double>>(Ny, std::vector<double>(Nz)));
-    std::vector<std::vector<std::vector<double>>> dQdevy(Nx, std::vector<std::vector<double>>(Ny, std::vector<double>(Nz)));
-    std::vector<std::vector<std::vector<double>>> dQdevz(Nx, std::vector<std::vector<double>>(Ny, std::vector<double>(Nz)));
-    #ifdef PARALLEL 
-    #pragma omp parallel for schedule(dynamic) 
+    #ifdef PARALLEL
+    #pragma omp parallel for schedule(dynamic)
     #endif
     for (int i = 0; i < Nx; ++i){
         for (int j = 0; j < Ny; ++j){
@@ -184,19 +184,32 @@ void LBM::calculate_moment_point(int i, int j, int k)
 #elif defined MULTICOMP
 void LBM::calculate_moment()
 {
-    #ifdef PARALLEL 
-    #pragma omp parallel for schedule(dynamic) 
+    #ifdef PARALLEL
+    #pragma omp parallel
+    #endif
+    {
+    // thread-local Cantera objects and work buffers, reused for every cell
+    int rank = omp_get_thread_num();
+    auto gas = sols[rank]->thermo();
+    auto trans = sols[rank]->transport();
+    const int ld = nSpeciesCantera;
+    std::vector<double> Y (nSpeciesCantera);
+    std::vector<double> X (nSpeciesCantera);
+    std::vector<double> d (ld * ld);
+    Eigen::MatrixXd matrix_A(nSpecies, nSpecies);
+    Eigen::VectorXd vector_rx(nSpecies);
+    Eigen::VectorXd vector_ry(nSpecies);
+    Eigen::VectorXd vector_rz(nSpecies);
+
+    #ifdef PARALLEL
+    #pragma omp for collapse(2) schedule(dynamic)
     #endif
     for (int i = 0; i < Nx; ++i){
         for (int j = 0; j < Ny; ++j){
             for (int k = 0; k < Nz; ++k){
                 if (mixture[i][j][k].type==TYPE_F){
-                    // create Cantera Object
-                    int rank = omp_get_thread_num();
-                    auto gas = sols[rank]->thermo();
-                    std::vector<double> Y (gas->nSpecies());
-                    std::vector<double> X (gas->nSpecies());
-                    for(size_t a = 0; a < nSpecies; ++a) Y[gas->speciesIndex(speciesName[a])] = species[a][i][j][k].rho / mixture[i][j][k].rho;
+                    std::fill(Y.begin(), Y.end(), 0.0);
+                    for(size_t a = 0; a < nSpecies; ++a) Y[speciesIdx[a]] = species[a][i][j][k].rho / mixture[i][j][k].rho;
                     gas->setMassFractions(&Y[0]);
                     gas->setState_TD(units.si_temp(mixture[i][j][k].temp), units.si_rho(mixture[i][j][k].rho));
 
@@ -233,26 +246,18 @@ void LBM::calculate_moment()
                     double rhov_a[nSpecies] = {0.0};
                     double rhow_a[nSpecies] = {0.0};
 
-                    for(size_t a = 0; a < nSpecies; ++a){           
-                        for(int p=0; p < 3; ++p)
-                            for(int q=0; q < 3; ++q)
-                                species[a][i][j][k].p_tensor[p][q] = 0.0;
-
+                    for(size_t a = 0; a < nSpecies; ++a){
                         for (int l = 0; l < npop; ++l){
                             rho_a[a]  += species[a][i][j][k].f[l];
                             rhou_a[a] += species[a][i][j][k].f[l]*cx[l];
                             rhov_a[a] += species[a][i][j][k].f[l]*cy[l];
                             rhow_a[a] += species[a][i][j][k].f[l]*cz[l];
 
-                            // std::cout << a  << " | " << species[a][i][j][k].f[l] << std::endl;
-
                             double velocity_set[3] = {cx[l], cy[l], cz[l]};
 
                             for(int p=0; p < 3; ++p)
-                                for(int q=0; q < 3; ++q){
-                                    species[a][i][j][k].p_tensor[p][q] += species[a][i][j][k].f[l]*velocity_set[p]*velocity_set[q];
+                                for(int q=0; q < 3; ++q)
                                     mixture[i][j][k].p_tensor[p][q] += species[a][i][j][k].f[l]*velocity_set[p]*velocity_set[q];
-                                }
                         }
                         if (rho_a[a] > SPECIES_MIN)
                         {
@@ -282,37 +287,28 @@ void LBM::calculate_moment()
                     mixture[i][j][k].w = rhow / rho;
                                         
                     // -------------------------------------------------------------------------------------------------------------------------------
-                    int ld = gas->nSpecies();
-                    std::vector<double> d(ld * ld);
-                    auto trans=sols[rank]->transport();
                     trans->getBinaryDiffCoeffs(ld, &d[0]);
 
                     double D_ab[nSpecies][nSpecies];
-                    for(size_t a = 0; a < nSpecies; ++a)                      
+                    for(size_t a = 0; a < nSpecies; ++a)
                         for(size_t b = 0; b <= a; ++b){
-                            D_ab[a][b] =  units.nu( d[ld*gas->speciesIndex(speciesName[b]) + gas->speciesIndex(speciesName[a])] );
+                            D_ab[a][b] =  units.nu( d[ld*speciesIdx[b] + speciesIdx[a]] );
                             D_ab[b][a] = D_ab[a][b];
                         }
 
-                    Eigen::SparseMatrix<double> matrix_A(nSpecies, nSpecies);
-                    Eigen::VectorXd vector_rx(nSpecies);
-                    Eigen::VectorXd vector_ry(nSpecies);
-                    Eigen::VectorXd vector_rz(nSpecies);
-                    Eigen::VectorXd vector_u(nSpecies);
-                    Eigen::VectorXd vector_v(nSpecies);
-                    Eigen::VectorXd vector_w(nSpecies); 
-
+                    // dense symmetric system (the matrix is fully populated anyway,
+                    // so a dense Cholesky factorization is much faster than a per-cell sparse solver)
                     for(size_t a = 0; a < nSpecies; ++a)
                         for(size_t b = 0; b < nSpecies; ++b)
-                            if(b != a) matrix_A.insert(a, b) = -1.0 * dt_sim/2.0 * mixture[i][j][k].p * species[a][i][j][k].X*species[b][i][j][k].X/D_ab[a][b];
+                            if(b != a) matrix_A(a, b) = -1.0 * dt_sim/2.0 * mixture[i][j][k].p * species[a][i][j][k].X*species[b][i][j][k].X/D_ab[a][b];
                             else {
-                                if(species[a][i][j][k].rho == 0.0) matrix_A.insert(a, b) = 1.0;
-                                else matrix_A.insert(a, b) = species[a][i][j][k].rho;
+                                if(species[a][i][j][k].rho == 0.0) matrix_A(a, b) = 1.0;
+                                else matrix_A(a, b) = species[a][i][j][k].rho;
                             }
 
                     for(size_t a = 0; a < nSpecies; ++a)
                         for(size_t b = 0; b < nSpecies; ++b)
-                            if (b != a) matrix_A.coeffRef(a, a) -= matrix_A.coeffRef(a,b);
+                            if (b != a) matrix_A(a, a) -= matrix_A(a,b);
 
                     for(size_t a = 0; a < nSpecies; ++a){
                         vector_rx(a) = rhou_a[a];
@@ -320,15 +316,11 @@ void LBM::calculate_moment()
                         vector_rz(a) = rhow_a[a];
                     }
 
-                    // Eigen::SparseLU<Eigen::SparseMatrix<double> , Eigen::COLAMDOrdering<int> > solver;
-                    Eigen::SimplicialLLT<Eigen::SparseMatrix<double> > solver;
-                    // solver.analyzePattern(matrix_A);
-                    // solver.factorize(matrix_A);                
-                    solver.compute(matrix_A);
+                    Eigen::LLT<Eigen::MatrixXd> solver(matrix_A);
 
-                    vector_u = solver.solve(vector_rx);
-                    vector_v = solver.solve(vector_ry);
-                    vector_w = solver.solve(vector_rz);
+                    Eigen::VectorXd vector_u = solver.solve(vector_rx);
+                    Eigen::VectorXd vector_v = solver.solve(vector_ry);
+                    Eigen::VectorXd vector_w = solver.solve(vector_rz);
 
                     for(size_t a = 0; a < nSpecies; ++a){
                         species[a][i][j][k].u = vector_u(a);
@@ -340,7 +332,7 @@ void LBM::calculate_moment()
 
 
                     std::fill(Y.begin(), Y.end(), 0.0);
-                    for(size_t a = 0; a < nSpecies; ++a) Y[gas->speciesIndex(speciesName[a])] = species[a][i][j][k].rho / mixture[i][j][k].rho;
+                    for(size_t a = 0; a < nSpecies; ++a) Y[speciesIdx[a]] = species[a][i][j][k].rho / mixture[i][j][k].rho;
                     gas->setMassFractions(&Y[0]);
 
                     #ifndef ISOTHERM
@@ -358,15 +350,16 @@ void LBM::calculate_moment()
                     #endif
                     
                     gas->getMoleFractions(&X[0]);
-                    for(size_t a = 0; a < nSpecies; ++a) species[a][i][j][k].X = X[gas->speciesIndex(speciesName[a])];
-            
-                    mixture[i][j][k].temp = units.temp(gas->temperature()); 
-                    mixture[i][j][k].p = units.p(gas->pressure()); 
+                    for(size_t a = 0; a < nSpecies; ++a) species[a][i][j][k].X = X[speciesIdx[a]];
+
+                    mixture[i][j][k].temp = units.temp(gas->temperature());
+                    mixture[i][j][k].p = units.p(gas->pressure());
 
                 }
             }
         }
     }
+    } // end parallel region
 
     // fill_BC();
 }
@@ -406,26 +399,18 @@ void LBM::calculate_moment_point(int i, int j, int k)
     double rhov_a[nSpecies] = {0.0};
     double rhow_a[nSpecies] = {0.0};
 
-    for(size_t a = 0; a < nSpecies; ++a){           
-        for(int p=0; p < 3; ++p)
-            for(int q=0; q < 3; ++q)
-                species[a][i][j][k].p_tensor[p][q] = 0.0;
-
+    for(size_t a = 0; a < nSpecies; ++a){
         for (int l = 0; l < npop; ++l){
             rho_a[a]  += species[a][i][j][k].f[l];
             rhou_a[a] += species[a][i][j][k].f[l]*cx[l];
             rhov_a[a] += species[a][i][j][k].f[l]*cy[l];
             rhow_a[a] += species[a][i][j][k].f[l]*cz[l];
 
-            // std::cout << a  << " | " << species[a][i][j][k].f[l] << std::endl;
-
             double velocity_set[3] = {cx[l], cy[l], cz[l]};
 
             for(int p=0; p < 3; ++p)
-                for(int q=0; q < 3; ++q){
-                    species[a][i][j][k].p_tensor[p][q] += species[a][i][j][k].f[l]*velocity_set[p]*velocity_set[q];
+                for(int q=0; q < 3; ++q)
                     mixture[i][j][k].p_tensor[p][q] += species[a][i][j][k].f[l]*velocity_set[p]*velocity_set[q];
-                }
         }
         if (rho_a[a] != 0)
         {
@@ -457,42 +442,39 @@ void LBM::calculate_moment_point(int i, int j, int k)
     // create Cantera Object
     int rank = omp_get_thread_num();
     auto gas = sols[rank]->thermo();
-    std::vector<double> Y (gas->nSpecies());
-    std::vector<double> X (gas->nSpecies());
-    for(size_t a = 0; a < nSpecies; ++a) Y[gas->speciesIndex(speciesName[a])] = species[a][i][j][k].rho / mixture[i][j][k].rho;
+    std::vector<double> Y (nSpeciesCantera);
+    std::vector<double> X (nSpeciesCantera);
+    for(size_t a = 0; a < nSpecies; ++a) Y[speciesIdx[a]] = species[a][i][j][k].rho / mixture[i][j][k].rho;
     gas->setMassFractions(&Y[0]);
     gas->setState_TD(units.si_temp(mixture[i][j][k].temp), units.si_rho(mixture[i][j][k].rho));
-                        
+
     // -------------------------------------------------------------------------------------------------------------------------------
-    int ld = gas->nSpecies();
+    const int ld = nSpeciesCantera;
     std::vector<double> d(ld * ld);
     auto trans=sols[rank]->transport();
     trans->getBinaryDiffCoeffs(ld, &d[0]);
 
     double D_ab[nSpecies][nSpecies];
-    for(size_t a = 0; a < nSpecies; ++a)                      
+    for(size_t a = 0; a < nSpecies; ++a)
         for(size_t b = 0; b < nSpecies; ++b)
-            D_ab[a][b] =  units.nu( d[ld*gas->speciesIndex(speciesName[b]) + gas->speciesIndex(speciesName[a])] );
+            D_ab[a][b] =  units.nu( d[ld*speciesIdx[b] + speciesIdx[a]] );
 
-    Eigen::SparseMatrix<double> matrix_A(nSpecies, nSpecies);
+    Eigen::MatrixXd matrix_A(nSpecies, nSpecies);
     Eigen::VectorXd vector_rx(nSpecies);
     Eigen::VectorXd vector_ry(nSpecies);
     Eigen::VectorXd vector_rz(nSpecies);
-    Eigen::VectorXd vector_u(nSpecies);
-    Eigen::VectorXd vector_v(nSpecies);
-    Eigen::VectorXd vector_w(nSpecies); 
 
     for(size_t a = 0; a < nSpecies; ++a)
         for(size_t b = 0; b < nSpecies; ++b)
-            if(b != a) matrix_A.insert(a, b) = -1.0 * dt_sim/2.0 * mixture[i][j][k].p * species[a][i][j][k].X*species[b][i][j][k].X/D_ab[a][b];
+            if(b != a) matrix_A(a, b) = -1.0 * dt_sim/2.0 * mixture[i][j][k].p * species[a][i][j][k].X*species[b][i][j][k].X/D_ab[a][b];
             else {
-                if(species[a][i][j][k].rho == 0.0) matrix_A.insert(a, b) = 1.0;
-                else matrix_A.insert(a, b) = species[a][i][j][k].rho;
+                if(species[a][i][j][k].rho == 0.0) matrix_A(a, b) = 1.0;
+                else matrix_A(a, b) = species[a][i][j][k].rho;
             }
 
     for(size_t a = 0; a < nSpecies; ++a)
         for(size_t b = 0; b < nSpecies; ++b)
-            if (b != a) matrix_A.coeffRef(a, a) -= matrix_A.coeffRef(a,b);
+            if (b != a) matrix_A(a, a) -= matrix_A(a,b);
 
     for(size_t a = 0; a < nSpecies; ++a){
         vector_rx(a) = rhou_a[a];
@@ -500,15 +482,11 @@ void LBM::calculate_moment_point(int i, int j, int k)
         vector_rz(a) = rhow_a[a];
     }
 
-    // Eigen::SparseLU<Eigen::SparseMatrix<double> , Eigen::COLAMDOrdering<int> > solver;
-    Eigen::SparseLU<Eigen::SparseMatrix<double> > solver;
-    solver.analyzePattern(matrix_A);
-    solver.factorize(matrix_A);                
-    solver.compute(matrix_A);
+    Eigen::PartialPivLU<Eigen::MatrixXd> solver(matrix_A);
 
-    vector_u = solver.solve(vector_rx);
-    vector_v = solver.solve(vector_ry);
-    vector_w = solver.solve(vector_rz);
+    Eigen::VectorXd vector_u = solver.solve(vector_rx);
+    Eigen::VectorXd vector_v = solver.solve(vector_ry);
+    Eigen::VectorXd vector_w = solver.solve(vector_rz);
 
     for(size_t a = 0; a < nSpecies; ++a){
         species[a][i][j][k].u = vector_u(a);
@@ -519,7 +497,7 @@ void LBM::calculate_moment_point(int i, int j, int k)
     // ------------------------------------------------------------------------------------------
 
     std::fill(Y.begin(), Y.end(), 0.0);
-    for(size_t a = 0; a < nSpecies; ++a) Y[gas->speciesIndex(speciesName[a])] = species[a][i][j][k].rho / mixture[i][j][k].rho;
+    for(size_t a = 0; a < nSpecies; ++a) Y[speciesIdx[a]] = species[a][i][j][k].rho / mixture[i][j][k].rho;
     gas->setMassFractions(&Y[0]);
 
     #ifndef ISOTHERM
@@ -534,10 +512,10 @@ void LBM::calculate_moment_point(int i, int j, int k)
     #endif
     
     gas->getMoleFractions(&X[0]);
-    for(size_t a = 0; a < nSpecies; ++a) species[a][i][j][k].X = X[gas->speciesIndex(speciesName[a])];
+    for(size_t a = 0; a < nSpecies; ++a) species[a][i][j][k].X = X[speciesIdx[a]];
 
-    mixture[i][j][k].temp = units.temp(gas->temperature()); 
-    mixture[i][j][k].p = units.p(gas->pressure()); 
+    mixture[i][j][k].temp = units.temp(gas->temperature());
+    mixture[i][j][k].p = units.p(gas->pressure());
     // gas_const = units.cp(Cantera::GasConstant/gas->meanMolecularWeight());
 
 }
@@ -547,10 +525,10 @@ double LBM::calculate_temp(double U, double rho, double rho_a[])
 {
     int rank = omp_get_thread_num();
     auto gas = sols[rank]->thermo();
-    std::vector <double> Y (gas->nSpecies());
+    std::vector <double> Y (nSpeciesCantera);
 
     for(size_t a = 0; a < nSpecies; ++a){
-        Y[gas->speciesIndex(speciesName[a])] = rho_a[a] / rho;
+        Y[speciesIdx[a]] = rho_a[a] / rho;
     }
     gas->setMassFractions(&Y[0]);
     gas->setState_UV(units.si_energy_mass(U), 1.0/units.si_rho(rho));


### PR DESCRIPTION
Speed (measured on MICROCHANNEL_FLAME, 100 steps: 14.5s -> 10.0s, 4 threads):
- Precompute Cantera species indices and molecular weights once in the LBM constructor instead of doing string-based speciesIndex()/molecularWeight() lookups for every lattice cell every step (collision, moment, EDF, BC, NSCBC).
- Collide(): compute the neighbours' specific gas constant R/W_mean directly from the local mass fractions instead of pushing six full Cantera setMassFractions+setState_TD updates per cell per step.
- Hoist all per-cell std::vector allocations (Y, X, w_dot, partial enthalpies, species viscosities, binary diffusion matrix) out of the triple loops into per-thread buffers reused across cells.
- calculate_moment(): replace the per-cell Eigen SparseMatrix build (insert/coeffRef) + SimplicialLLT with a dense MatrixXd + LLT Cholesky of the same symmetric system; the matrix is fully populated anyway. calculate_moment_point() likewise uses dense PartialPivLU instead of SparseLU.
- Pass LBM by reference in the NSCBC helpers; they previously copied the whole LBM object (including the species-name vector) on every call per boundary cell.
- collapse(2) on the OpenMP loops of the heavy kernels for better load balance.

Memory (191 MB -> 170 MB on the same case):
- Remove SPECIES::p_tensor, which was computed and stored but never read (mixture p_tensor is kept). NOTE: this changes sizeof(SPECIES), so binary restart files written by older builds cannot be read by this build.
- Allocate the mixture and species lattices as single contiguous blocks with row-pointer tables (same mixture[i][j][k] indexing) instead of Nx*Ny separate heap allocations per field, improving locality and removing allocator overhead.
- Drop three unused Nx*Ny*Nz scratch vectors allocated on every calculate_moment() call in the non-MULTICOMP build.

Correctness notes:
- Reaction source terms and HRR now index Cantera arrays via the precomputed species index (w_dot[speciesIdx[a]], part_enthalpy[speciesIdx[a]]) instead of assuming the simulated species order matches the mechanism order; identical behaviour when the full mechanism species list is used (as in all current setups), correct for subsets.
- MIXTURE::rho now has a default value so never-written boundary/ghost cells no longer dump uninitialized memory into the VTK output.

Verified against the unoptimized build on MICROCHANNEL_FLAME: initial fields bit-identical; after 100 steps temperature/pressure/mole fractions agree to ~1e-7 relative (float32 output precision).


Claude-Session: https://claude.ai/code/session_014PPrjxDnJEDfFHoYGeAsr6